### PR TITLE
DAYD-725 add plansテーブルのis_required_planとis_parent_planにデフォルト値を設定

### DIFF
--- a/postgres/src/01_ddl/10005_create_table_plans.sql
+++ b/postgres/src/01_ddl/10005_create_table_plans.sql
@@ -14,8 +14,8 @@ CREATE TABLE "plans"
   "priority"         INTEGER      NOT NULL,
   "place"            VARCHAR(100),
   "is_scheduled"     BOOLEAN      DEFAULT FALSE,
-  "is_required_plan" BOOLEAN,
+  "is_required_plan" BOOLEAN      DEFAULT TRUE,
   "parent_plan_id"   INTEGER,
-  "is_parent_plan"   BOOLEAN,
+  "is_parent_plan"   BOOLEAN      DEFAULT FALSE,
   "todo_start_time"  TIMESTAMP
 );


### PR DESCRIPTION
# 事前確認

-   [x] PR前に動作確認をしたか
-   [x] ビルドエラー/ESLintエラーは起きていないか
-   [x] [開発ルール](https://daydule.atlassian.net/wiki/spaces/DAYDULE/pages/9765029)を守って実装しているか
-   [x] 単体テストが全てOKになっているか
-   [x] 機密情報を含んでいないか
-   [x] 最新の`develop`ブランチを反映しているか

# やったこと
<!-- このプルリクエストでやったことを書く -->
プルリクタイトルの通り

# やらないこと
<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->
なし

# 懸念点や注意点
<!-- このプルリクエストにおける懸念点や注意点を書く -->
なし

# その他
<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->
なし